### PR TITLE
realpath replaced with ${PWD}/$0 because not every OS have it

### DIFF
--- a/tools/build-packages.sh
+++ b/tools/build-packages.sh
@@ -9,7 +9,7 @@ fi
 set -eux
 
 REPO_URL="https://${org}.storage.googleapis.com"
-repo_dir="$(dirname "$(dirname "$(realpath $0)")")"
+repo_dir="$(dirname "$(dirname "${PWD}/$0")")"
 
 # build dependencies
 for d in ${repo_dir}/charts/*/; do


### PR DESCRIPTION
Hi guys
Have tried to use this script to build packages but wasn't able to do so because absence of realpath. So this fix should help to avoid that.