### PR TITLE
zookeeper: use storageClassName instead of annotation

### DIFF
--- a/charts/zookeeper/templates/zookeeper/statefulset.yaml
+++ b/charts/zookeeper/templates/zookeeper/statefulset.yaml
@@ -158,12 +158,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      {{- if .Values.persistence.storageClass }}
-      annotations:
-        volume.beta.kubernetes.io/storage-class: "{{ .Values.persistence.storageClass }}"
-      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.persistence.storageClass }}
+      storageClassName: "{{ .Values.persistence.storageClass }}"
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistence.volumeSize }}


### PR DESCRIPTION
I'm using AKS and the annotation isn't being recognized. The annotation has been deprecated since 1.6.

https://github.com/kubernetes/charts/issues/1869